### PR TITLE
GPX-407 - made keycloak-instance on play target a fixed revision

### DIFF
--- a/cluster-setup-checkpoint/gp-cluster-setup-checkpoint/values/values-play.yaml
+++ b/cluster-setup-checkpoint/gp-cluster-setup-checkpoint/values/values-play.yaml
@@ -97,7 +97,7 @@ applications:
     source:
       repoURL: "https://gepaplexx.github.io/gp-helm-charts/"
       chart: gp-keycloak-instance
-      targetRevision: "*"
+      targetRevision: "0.1.*"
       helm:
         parameters:
           - name: "ingress.hostname"


### PR DESCRIPTION
Newer versions of the keycloak-instance chart being deployed caused issues with signing into vault (because the actual keycloak server didn't get deployed)