### PR TITLE
GPX-468 - aufräumen von grafana konfiguration

### DIFF
--- a/cluster-applications/gp-cluster-applications/values/values-play.yaml
+++ b/cluster-applications/gp-cluster-applications/values/values-play.yaml
@@ -205,8 +205,6 @@ applications:
       chart: "gp-grafana-instance"
       helm:
         parameters:
-          - name: "datasource.prometheus.url"
-            value: "https://thanos-querier-openshift-monitoring.apps.play.gepaplexx.com:443"
           - name: "ingress.hostname"
             value: "grafana.apps.play.gepaplexx.com"
           - name: "sso.keycloak.clientSecret"
@@ -214,14 +212,6 @@ applications:
           - name: "sso.keycloak.realmUrl"
             value: "https://sso.apps.play.gepaplexx.com/realms/internal"
     ignoreDifferences:
-      # TODO Remove ignoreDifferences section for datasources after GPX-495 has been implemented
-      - jsonPointers:
-          - /spec/datasources/0/secureJsonData/httpHeaderValue1
-          - /spec/datasources/1/secureJsonData/httpHeaderValue1
-          - /spec/datasources/2/secureJsonData/httpHeaderValue1
-          - /spec/datasources/3/secureJsonData/httpHeaderValue1
-        kind: GrafanaDataSource
-        group: integreatly.org
       - jsonPointers:
           - /spec/config/auth.generic_oauth/client_secret
         kind: Grafana

--- a/cluster-applications/gp-cluster-applications/values/values-play.yaml
+++ b/cluster-applications/gp-cluster-applications/values/values-play.yaml
@@ -51,10 +51,9 @@ applications:
           - name: "infranodes.enabled"
             value: "false"
     syncPolicy:
-      automated:
-        prune: true
-        selfHeal: true
-
+      automated: {}
+#        prune: true
+#        selfHeal: true
   ####################### CLUSTER-LOGGING-EVENTROUTER #######################
   clusterLoggingEventrouter:
     name: cluster-logging-eventrouter

--- a/cluster-applications/gp-cluster-applications/values/values-steppe.yaml
+++ b/cluster-applications/gp-cluster-applications/values/values-steppe.yaml
@@ -205,8 +205,6 @@ applications:
       chart: "gp-grafana-instance"
       helm:
         parameters:
-          - name: "datasource.prometheus.url"
-            value: "https://thanos-querier-openshift-monitoring.apps.steppe.gepaplexx.com:443"
           - name: "ingress.hostname"
             value: "grafana.apps.steppe.gepaplexx.com"
           - name: "sso.keycloak.clientSecret"
@@ -214,13 +212,6 @@ applications:
           - name: "sso.keycloak.realmUrl"
             value: "https://sso.apps.steppe.gepaplexx.com/realms/internal"
     ignoreDifferences:
-      - jsonPointers:
-          - /spec/datasources/0/secureJsonData/httpHeaderValue1
-          - /spec/datasources/1/secureJsonData/httpHeaderValue1
-          - /spec/datasources/2/secureJsonData/httpHeaderValue1
-          - /spec/datasources/3/secureJsonData/httpHeaderValue1
-        kind: GrafanaDataSource
-        group: integreatly.org
       - jsonPointers:
           - /spec/config/auth.generic_oauth/client_secret
         kind: Grafana


### PR DESCRIPTION
wir verwenden einen cluster-admin bearer token damit wir grafana ohne einschränkungen verwenden können. die datasource sind somit gesetzt und werden nicht mehr überschrieben.